### PR TITLE
Use RTLD_DEEPBIND to prevent jemalloc/glibc allocator mismatch

### DIFF
--- a/source/non_limited_api/non_limited_api_stubs.cpp
+++ b/source/non_limited_api/non_limited_api_stubs.cpp
@@ -15,7 +15,14 @@
 #ifdef __MUSL__
 #define PYBIND11_NONLIMITEDAPI_DLOPEN(dir, file) dlopen((dir + "lib" + file + PYBIND11_NONLIMITEDAPI_SHLIB_SUFFIX).c_str(), RTLD_NOW | RTLD_GLOBAL)
 #else
-#define PYBIND11_NONLIMITEDAPI_DLOPEN(dir, file) dlopen((dir + "lib" + file + PYBIND11_NONLIMITEDAPI_SHLIB_SUFFIX).c_str(), RTLD_NOW | RTLD_LOCAL)
+#ifndef RTLD_DEEPBIND
+#ifdef __linux__
+#error "RTLD_DEEPBIND is required on Linux to prevent jemalloc/glibc allocator mismatch"
+#else
+#define RTLD_DEEPBIND 0
+#endif
+#endif
+#define PYBIND11_NONLIMITEDAPI_DLOPEN(dir, file) dlopen((dir + "lib" + file + PYBIND11_NONLIMITEDAPI_SHLIB_SUFFIX).c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)
 #endif
 #define PYBIND11_NONLIMITEDAPI_DLOPEN_ERROR dlerror()
 #endif


### PR DESCRIPTION
Add RTLD_DEEPBIND flag to dlopen calls on non-musl platforms to ensure symbol isolation and prevent allocator conflicts between jemalloc and glibc malloc.